### PR TITLE
Remove unrequired 'using GLib'

### DIFF
--- a/src/mangojuice.vala
+++ b/src/mangojuice.vala
@@ -1,5 +1,4 @@
 using Gtk;
-using GLib;
 using Adw;
 using Gee;
 

--- a/src/save_states.vala
+++ b/src/save_states.vala
@@ -1,7 +1,6 @@
 // save_states.vala
 
 using Gtk;
-using GLib;
 using Adw;
 using Gee;
 


### PR DESCRIPTION
Including GLib namespace happends automaticaly