### PR TITLE
add debloated packages, fix CI building older commit

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -18,12 +18,8 @@ jobs:
       run: |
         pacman -Syu --noconfirm
         pacman -S --noconfirm git base-devel meson ninja fuse2 libsodium libgee gettext gtk4 libadwaita vala fontconfig glib2 wget patchelf strace xorg-server-xvfb vulkan-tools
-        
-    - name: Clone MangoJuice repository
-      run: git clone https://github.com/radiolamp/mangojuice.git
-        
+  
     - name: Build and install MangoJuice
-      working-directory: ./mangojuice
       run: |
         meson setup build --prefix=/usr
         ninja -C build

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -11,13 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: archlinux:latest
-      options: --privileged
 
     steps:
     - name: Update system and install dependencies
       run: |
         pacman -Syu --noconfirm
-        pacman -S --noconfirm git base-devel meson ninja fuse2 libsodium libgee gettext gtk4 libadwaita vala fontconfig glib2 wget patchelf strace xorg-server-xvfb vulkan-tools
+        pacman -S --noconfirm git base-devel meson ninja libsodium libgee gettext gtk4 libadwaita vala fontconfig glib2 wget patchelf strace xorg-server-xvfb vulkan-tools
   
     - name: Build and install MangoJuice
       run: |

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch: {}
 
 jobs:
   build:
@@ -13,6 +14,10 @@ jobs:
       image: archlinux:latest
 
     steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
     - name: Update system and install dependencies
       run: |
         pacman -Syu --noconfirm

--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -30,13 +30,12 @@ jobs:
         sudo ninja -C build install
         
     - name: Create AppImage
-      working-directory: ./mangojuice/build-aux
       run: |
-        chmod +x ./mangojuice-appimage.sh
-        ./mangojuice-appimage.sh
+        chmod +x ./build-aux/mangojuice-appimage.sh
+        ./build-aux/mangojuice-appimage.sh
         
     - name: Upload AppImage artifact
       uses: actions/upload-artifact@v4
       with:
         name: MangoJuice-AppImage
-        path: ./mangojuice/build-aux/MangoJuice-*.AppImage
+        path: MangoJuice-*.AppImage

--- a/build-aux/mangojuice-appimage.sh
+++ b/build-aux/mangojuice-appimage.sh
@@ -11,6 +11,36 @@ LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bi
 URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"
 URUNTIME_LITE="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-lite-$ARCH"
 
+# add debloated packages
+LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-$PKG_TYPE"
+LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
+MESA_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/mesa-mini-$PKG_TYPE"
+VK_RADEON_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/vulkan-radeon-mini-$PKG_TYPE"
+VK_INTEL_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/vulkan-intel-mini-$PKG_TYPE"
+VK_NOUVEAU_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/vulkan-nouveau-mini-$PKG_TYPE"
+VK_PANFROST_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/vulkan-panfrost-mini-$PKG_TYPE"
+VK_FREEDRENO_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/vulkan-freedreno-mini-$PKG_TYPE"
+VK_BROADCOM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/vulkan-broadcom-mini-$PKG_TYPE"
+
+echo "Installing debloated pckages..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$LLVM_URL"        -O  ./llvm-libs.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$LIBXML_URL"      -O  ./libxml2.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$MESA_URL"        -O  ./mesa.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$VK_RADEON_URL"   -O  ./vulkan-radeon.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$VK_NOUVEAU_URL"  -O  ./vulkan-nouveau.pkg.tar.zst
+
+if [ "$(uname -m)" = 'x86_64' ]; then
+	wget --retry-connrefused --tries=30 "$VK_INTEL_URL"     -O ./vulkan-intel.pkg.tar.zst
+else
+	wget --retry-connrefused --tries=30 "$VK_PANFROST_URL"  -O ./vulkan-panfrost.pkg.tar.zst
+	wget --retry-connrefused --tries=30 "$Vk_FREEDRENO_URL" -O ./vulkan-freedreno.pkg.tar.zst
+	wget --retry-connrefused --tries=30 "$Vk_BROADCOM_URL"  -O ./vulkan-broadcom.pkg.tar.zst
+fi
+
+pacman -U --noconfirm ./*.pkg.tar.zst
+rm -f ./*.pkg.tar.zst
+
 mkdir -p ./AppDir
 cd ./AppDir || exit
 
@@ -107,7 +137,7 @@ echo "Создание AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
     --set-owner 0 --set-group 0 \
     --no-history --no-create-timestamp \
-    --compression zstd:level=12 -S26 -B8 \
+    --compression zstd:level=22 -S26 -B8 \
     --header uruntime-lite \
     -i ./AppDir -o "MangoJuice-${VERSION}-${ARCH}.AppImage" || {
     echo "Ошибка создания AppImage"

--- a/build-aux/mangojuice-appimage.sh
+++ b/build-aux/mangojuice-appimage.sh
@@ -12,6 +12,12 @@ URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime
 URUNTIME_LITE="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-lite-$ARCH"
 
 # add debloated packages
+if [ "$(uname -m)" = 'x86_64' ]; then
+	PKG_TYPE='x86_64.pkg.tar.zst'
+else
+	PKG_TYPE='aarch64.pkg.tar.xz'
+fi
+
 LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-$PKG_TYPE"
 LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
 MESA_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/mesa-mini-$PKG_TYPE"


### PR DESCRIPTION
* The issue with the CI was that you were cloning the repo in it, that doesnt work because github doesn't sync instantly. Instead the repo needs to be checked out directly with the `actions/checkout@v4` action. 

* There is no need to install `fuse2` and use the `--privileged` flag in the container either.

-------------------------------------------------

Note the app takes 1.26 seconds to open on my PC with zstd22. Uncompressed it takes 0.85 seconds xd

![image](https://github.com/user-attachments/assets/647b8e6e-fa4d-4f87-ab67-b690de2896a7)


So I don't really see the point in adding a dwarfs profile to speedup the launch time, most of the delay is from gtk itself, [in fact form libadwaita](https://github.com/ivan-hc/AM/pull/1480)
