### PR TITLE
Use language agnostic flathub link for badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 **Flathub:**
 
-<a href="https://flathub.org/ru/apps/io.github.radiolamp.mangojuice">
+<a href="https://flathub.org/apps/io.github.radiolamp.mangojuice">
   <img width='240' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.svg'/>
 </a>
 


### PR DESCRIPTION
Removed  /ru/ from flathub link, as it was forcing the russian version of Flathub, regardless of the users' locale/lang. 